### PR TITLE
feat(fakers): ability to add fakers

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -115,8 +115,9 @@ def error(message):
 @click.option('--stand-alone', is_flag=True, help='Whether or not to de-reference JSON schemas')
 @click.option('--kubernetes', is_flag=True, help='Enable Kubernetes specific processors')
 @click.option('--strict', is_flag=True, help='Prohibits properties not in the schema (additionalProperties: false)')
+@click.option('--fakers', required=False, help='Enables registration of custom fakers. See https://git.io/vFAhp')
 @click.argument('schema', metavar='SCHEMA_URL')
-def default(output, schema, prefix, stand_alone, kubernetes, strict):
+def default(output, schema, fakers, prefix, stand_alone, kubernetes, strict):
     """
     Converts a valid OpenAPI specification into a set of JSON Schema files
     """
@@ -126,6 +127,11 @@ def default(output, schema, prefix, stand_alone, kubernetes, strict):
     # Note that JSON is valid YAML, so we can use the YAML parser whether
     # the schema is stored in JSON or YAML
     data = yaml.load(response.read())
+    fakers_defined = len(fakers) != 0
+    if fakers_defined:
+        info("Loading fakers")
+        with open(fakers, 'r') as stream:
+            fakers_definitions = yaml.safe_load(stream)
 
     if not os.path.exists(output):
         os.makedirs(output)
@@ -142,6 +148,14 @@ def default(output, schema, prefix, stand_alone, kubernetes, strict):
                 {'type': 'string'},
                 {'type': 'integer'},
             ]}
+
+        if fakers_defined:
+            for schema_type, faker in fakers_definitions.iteritems():
+                if schema_type in definitions:
+                    definitions[schema_type]['faker'] = faker
+                else:
+                    definitions[schema_type] = {'faker': faker}
+
         definitions_file.write(json.dumps({"definitions": definitions}, indent=2))
 
     types = []


### PR DESCRIPTION
As mentioned in #7 I am playing with fuzzy testing and for that I'm using https://github.com/json-schema-faker/json-schema-faker. I wanted to have an option of adding `fixer` fields while generating the schema, so I can influence how particular field is generated. I'm aware this can be done as part of OpenAPI extension in k8s upstream, but was wondering if we couldn't have this flexibility at this level for testing purposes.