### PR TITLE
Retain types from OpenAPI definitions

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -154,7 +154,7 @@ def default(output, schema, prefix, stand_alone, kubernetes, strict):
         kind = title.split('.')[-1].lower()
         specification = data['definitions'][title]
         specification["$schema"] ="http://json-schema.org/schema#"
-        specification["type"] = "object"
+        specification.setdefault("type", "object")
 
         types.append(title)
 


### PR DESCRIPTION
This commit  behavior that forced the type of each definition to
`object` and retains the original type in the specification. This allows
API definitions that have types such as `array` to be converted correctly.