### PR TITLE
Ensure additionalProperties are in local defs

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -145,6 +145,9 @@ def default(output, schema, prefix, stand_alone, kubernetes, strict):
                 {'type': 'string'},
                 {'type': 'integer'},
             ]}
+        if strict:
+            definitions = additional_properties(definitions)
+
         definitions_file.write(json.dumps({"definitions": definitions}, indent=2))
 
     types = []


### PR DESCRIPTION
Add `additionalProperties: "false"` to local files when in strict mode