### PR TITLE
Generate JSONSchemaProps and CustomResourceDefinitions

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -166,7 +166,7 @@ def default(output, schema, prefix, stand_alone, kubernetes, strict):
 
             # This list of Kubernets types carry around jsonschema for Kubernetes and don't
             # currently work with openapi2jsonschema
-            if kubernetes and kind in ["jsonschemaprops", "jsonschemapropsorarray", "customresourcevalidation", "customresourcedefinition", "customresourcedefinitionspec", "customresourcedefinitionlist", "customresourcedefinitionspec", "jsonschemapropsorstringarray", "jsonschemapropsorbool"]:
+            if kubernetes and stand_alone and kind in ["jsonschemaprops", "jsonschemapropsorarray", "customresourcevalidation", "customresourcedefinition", "customresourcedefinitionspec", "customresourcedefinitionlist", "customresourcedefinitionspec", "jsonschemapropsorstringarray", "jsonschemapropsorbool"]:
                 raise UnsupportedError("%s not currently supported" % kind)
 
             if stand_alone:


### PR DESCRIPTION
JSONSchemaProps and resources that rely on JSONSchemaProps such as
CustomResourceDefinitions are only problematic in standalone mode
because they generate circular references.

Generate the schema files for such resources when not in standalone
mode