### PR TITLE
Python 3 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pip-selfcheck.json
 MANIFEST
 Scripts
 tcl
+.vscode


### PR DESCRIPTION
Pretty simple, fix a couple of things so openapi2jsonschema works in Python 3:
* `d.iteritems() -> iter(d.items())`
* `basestring -> str`