### PR TITLE
For Kubernetes, populate `apiVersion` and `kind` properties from `x-kubernetes-group-version-kind`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pip-selfcheck.json
 MANIFEST
 Scripts
 tcl
+.vscode

--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -121,6 +121,17 @@ def change_dict_values(d, prefix, version):
         return d
 
 
+def append_no_duplicates(obj, key, value):
+    """
+    Given a dictionary, lookup the given key, if it doesn't exist create a new array.
+    Then check if the given value already exists in the array, if it doesn't add it.
+    """
+    if key not in obj:
+        obj[key] = []
+    if value not in obj[key]:
+        obj[key].append(value)
+
+
 def info(message):
     click.echo(click.style(message, fg='green'))
 
@@ -180,6 +191,18 @@ def default(output, schema, prefix, stand_alone, kubernetes, strict):
                     {'type': 'string'},
                     {'type': 'integer'},
                 ]}
+
+                # For Kubernetes, populate `apiVersion` and `kind` properties from `x-kubernetes-group-version-kind`
+                for type_name in definitions:
+                    type_def = definitions[type_name]
+                    if 'x-kubernetes-group-version-kind' in type_def:
+                        for kube_ext in type_def['x-kubernetes-group-version-kind']:
+                            if 'apiVersion' in type_def['properties']:
+                                api_version = kube_ext['group'] + '/' + kube_ext['version'] if kube_ext['group'] else kube_ext['version']
+                                append_no_duplicates(type_def['properties']['apiVersion'], 'enum', api_version)
+                            if 'kind' in type_def['properties']:
+                                kind = kube_ext['kind']
+                                append_no_duplicates(type_def['properties']['kind'], 'enum', kind)
             if strict:
                 definitions = additional_properties(definitions)
             definitions_file.write(json.dumps({"definitions": definitions}, indent=2))


### PR DESCRIPTION
This change depends on https://github.com/garethr/openapi2jsonschema/pull/17.

It adds support for enumerating the supported `apiVersion` and `kind` values in the Kubernetes schema from `x-kubernetes-group-version-kind`.

Here's an example of the change in the output:
```
--- a/v1.9.11/volumeattachmentlist.json
+++ b/v1.9.11/volumeattachmentlist.json
@@ -9,6 +9,9 @@
       "type": [
         "string",
         "null"
+      ],
+      "enum": [
+        "storage.k8s.io/v1alpha1"
       ]
     },
     "items": {
@@ -26,6 +29,9 @@
       "type": [
         "string",
         "null"
+      ],
+      "enum": [
+        "VolumeAttachmentList"
       ]
     },
     "metadata": {
```