### PR TITLE
remove the lower to make kind and title case match : this make file name and ref file name match

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -127,7 +127,7 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
         components = data["components"]["schemas"]
 
     for title in components:
-        kind = title.split(".")[-1].lower()
+        kind = title.split(".")[-1]
         if kubernetes:
             group = title.split(".")[-3].lower()
             api_version = title.split(".")[-2].lower()


### PR DESCRIPTION
without this changes when components use camelcase `MyComponent` this result into
- the generated schema will be  `mycomponent.json`
- the reference to this component from the other schema will be `"$ref": "MyComponent.json"`
the case don't match