### PR TITLE
Add support for nullable OpenAPI fields

### DIFF
--- a/openapi2jsonschema/util.py
+++ b/openapi2jsonschema/util.py
@@ -77,7 +77,10 @@ def allow_null_optional_fields(data, parent=None, grand_parent=None, key=None):
 def change_dict_values(d, prefix, version):
     new = {}
     try:
+        is_nullable = False
         for k, v in iteritems(d):
+            if k == 'nullable':
+                is_nullable = True
             new_v = v
             if isinstance(v, dict):
                 new_v = change_dict_values(v, prefix, version)
@@ -94,6 +97,10 @@ def change_dict_values(d, prefix, version):
             else:
                 new_v = v
             new[k] = new_v
+        if is_nullable and 'type' in new:
+            if not isinstance(new['type'], list):
+                new['type'] = [new['type']]
+            new['type'].append('null')
         return new
     except AttributeError:
         return d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["openapi", "jsonschema"]
 python = "^3.7"
 jsonref = "^0.2.0"
 pyyaml = "^5.1"
-click = "^7.0"
+click = "^8.0"
 colorama = "^0.4.1"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
If nullable attribute of a field in OpenAPI spec is set, add 'null' to the list of types in JSON schema (and turn type into list if it's a primitive type)