### PR TITLE
Support for windows local file paths

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -58,7 +58,14 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
         response = urllib.urlopen(schema)
     else:
         if os.path.isfile(schema):
-            schema = "file://" + os.path.realpath(schema)
+            if sys.version_info >= (3, 4):
+                import pathlib
+                schema = pathlib.Path(os.path.realpath(schema)).as_uri()
+            else:
+                schema = schema = 'file://' + os.path.realpath(schema)  # does not support windows
+        req = urllib.request.Request(schema)
+        response = urllib.request.urlopen(req)
+
         req = urllib.request.Request(schema)
         response = urllib.request.urlopen(req)
 

--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -65,10 +65,6 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
                 schema = schema = 'file://' + os.path.realpath(schema)  # does not support windows
         req = urllib.request.Request(schema)
         response = urllib.request.urlopen(req)
-
-        req = urllib.request.Request(schema)
-        response = urllib.request.urlopen(req)
-
     info("Parsing schema")
     # Note that JSON is valid YAML, so we can use the YAML parser whether
     # the schema is stored in JSON or YAML


### PR DESCRIPTION
CLI throws when provided with a file path instead of a URI on windows due to slash direction differences