### PR TITLE
openapijson2schema/command.py: throw error instead of proceeding

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -71,6 +71,8 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
         version = data["swagger"]
     elif "openapi" in data:
         version = data["openapi"]
+    else:
+        raise ValueError("cannot convert data to JSON because we could not find 'openapi' or 'swagger' keys")
 
     if not os.path.exists(output):
         os.makedirs(output)


### PR DESCRIPTION
If we can't find either 'swagger' or 'openapi' keys, previously we'd
get an UnboundLocalError because of an undefined variable. Even if we
fixed that, it is probably bad to continue with command flow when the
behavior is not well defined. Instead throw an error to exit execution
immediately.

Fixes #16.