### PR TITLE
Update build-system to allow for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,5 @@ pytest-cov = "^2.6"
 pytest-datafiles = "^2.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Before:

```
$ pip install -e .
Obtaining file:///Users/akx/build/openapi2jsonschema
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
ERROR: Project file:///Users/akx/build/openapi2jsonschema has a 'pyproject.toml' and its build backend is missing the 'build_editable' hook. Since it does not have a 'setup.py' nor a 'setup.cfg', it cannot be installed in editable mode. Consider using a build backend that supports PEP 660.
```

After:

```
$ pip install -e .
Obtaining file:///Users/akx/build/openapi2jsonschema
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Successfully installed click-7.1.2 colorama-0.4.6 jsonref-0.2 openapi2jsonschema-0.9.0 pyyaml-5.4.1
```